### PR TITLE
Match more liberally on URL segments

### DIFF
--- a/src/list-tabs.js
+++ b/src/list-tabs.js
@@ -36,7 +36,7 @@ function run(args) {
         windowIndex: w,
         tabIndex: t,
         arg: `${w},${t},${url}`,
-        match: `${title} ${matchUrl}`,
+        match: `${title} ${matchUrl.replaceAll(/[^\w]/g, " ")}`,
       };
     }
   }


### PR DESCRIPTION
Items only match if the search string a word in the `match` property from the start. This can be inconvenient, for example when we want to open a tab where Spotify is playing. When playing, the tab title doesn't include the word "Spotify".

Ideally, we could type "spotify" and have the tab match, but the `match` property looks like `Song Name . Artist open.spotify.com/user/<username>`. We'll get a match if we type "open.spotify", but not if we type "spotify".

This change splits `matchUrl` into many elements for more liberal keyword matching. Tabs will now match any subdomain, the root domain, or any element of the path or query.

With this change, the tab from the previous scenario would have a `match` property of `Song Name . Artist open spotify com user <username>`. Since this includes the word "spotify", it will match our search string.

Absolutely no offence taken if this is not behaviour you want! Just offering the patch in case you like it.