### PR TITLE
add decodeURI before relpacing non-word characters

### DIFF
--- a/src/list-tabs-webkit.js
+++ b/src/list-tabs-webkit.js
@@ -34,7 +34,7 @@ function run(args) {
         tabIndex: t,
         quicklookurl: url,
         arg: `${w},${url || title}`,
-        match: `${title} ${matchUrl.replaceAll(/[^\w]/g, " ")}`,
+        match: `${title} ${decodeURIComponent(matchUrl).replaceAll(/[^\w]/g, " ")}`,
       };
     }
   }

--- a/src/list-tabs.js
+++ b/src/list-tabs.js
@@ -37,7 +37,7 @@ function run(args) {
         tabIndex: t,
         quicklookurl: url,
         arg: `${w},${t},${url}`,
-        match: `${title} ${matchUrl.replaceAll(/[^\w]/g, " ")}`,
+        match: `${title} ${decodeURIComponent(matchUrl).replaceAll(/[^\w]/g, " ")}`,
       };
     }
   }


### PR DESCRIPTION
Use url decode to convert back more  non-word characters to enhance Alfred search.

For example:

> https://github.com/epilande/alfred-browser-tabs/issues?q=is%3Aissue+is%3Aclosed+label%3Adocumentation

Before:
<img width="1804" alt="image" src="https://user-images.githubusercontent.com/1673006/132986573-107c08ff-4aca-4c44-848d-d31877a3b79a.png">


After:
<img width="1716" alt="image" src="https://user-images.githubusercontent.com/1673006/132986546-b4d4c55e-ce2a-44a3-919d-36cf43573f23.png">


<img width="757" alt="image" src="https://user-images.githubusercontent.com/1673006/132986674-7d535960-375c-4454-bb14-cc72a1818110.png">
