### PR TITLE
replaceAll() not available

### DIFF
--- a/src/list-tabs.js
+++ b/src/list-tabs.js
@@ -37,7 +37,7 @@ function run(args) {
         tabIndex: t,
         quicklookurl: url,
         arg: `${w},${t},${url}`,
-        match: `${title} ${matchUrl.replaceAll(/[^\w]/g, " ")}`,
+        match: `${title} ${matchUrl.replace(/[^\w]/g, " ")}`,
       };
     }
   }


### PR DESCRIPTION
matchUrl.replaceAll() gives the following error message:

```
./list-tabs.js:990:1054: execution error: Error on line 39: TypeError: matchUrl.replaceAll is not a function. (In 'matchUrl.replaceAll(/[^\w]/g, "
")', 'matchUrl.replaceAll' is undefined) (-2700)
```

I'm not sure what version of JS `osascript -l JavaScript` is running. It is probably just an older version on my machine (macOS 10.14.6).  I believe using  .match() with the `g` flag on the regular expression accomplishes the same goal.