### PR TITLE
Update description to match repo

### DIFF
--- a/src/info.plist
+++ b/src/info.plist
@@ -309,7 +309,7 @@
 	<key>createdby</key>
 	<string>Emmanuel Pilande</string>
 	<key>description</key>
-	<string>Search browser tabs from Chrome, Brave, &amp; Safari</string>
+	<string>Search browser tabs from Chrome, Brave, Safari, etc..</string>
 	<key>disabled</key>
 	<false/>
 	<key>name</key>


### PR DESCRIPTION
It’s not just three browsers anymore, so updated the description according to the one in the repo:

<img width="316" src="https://user-images.githubusercontent.com/1699443/193698159-3ae87490-9699-446e-a21c-b94e78a2176c.png">