### PR TITLE
fix: Focus window properly when switching to a tab in a currently-unfocused window

### DIFF
--- a/src/focus-tab.js
+++ b/src/focus-tab.js
@@ -39,7 +39,8 @@ function getBrowserAndWindows(windowIndex) {
  *
  * In most cases, the system window at the same index should match the browser window, and we can
  * return that. However, things like alerts or dialogs can cause the system windows and browser
- * windows to differ in order and/or count.
+ * windows to differ in order and/or count, in which case we manually search for the system window
+ * with the expected title prefix.
  */
 function getSystemWindow(browserName, windowIndex, browserWindowTitle) {
   const browserProcess = Application("System Events").processes[browserName];

--- a/src/focus-tab.js
+++ b/src/focus-tab.js
@@ -37,7 +37,7 @@ function getBrowserAndWindows(windowIndex) {
 /**
  * Returns the system window matching the browser window title, if found. Else returns undefined.
  *
- * In most cases, the system window at the given index should match the browser window, and we can
+ * In most cases, the system window at the same index should match the browser window, and we can
  * return that. However, things like alerts or dialogs can cause the system windows and browser
  * windows to differ in order and/or count.
  */
@@ -74,16 +74,15 @@ function getSystemWindowByIndex(
 /**
  * Returns the first system window with the expected title prefix, or undefined if not found.
  */
-function getSystemWindowByTitle(browserProcess, expectedWindowTitlePrefix) {
+function getSystemWindowByTitle(browserProcess, expectedTitlePrefix) {
   const systemWindows = browserProcess.windows();
-  const matchingSystemWindows = systemWindows.filter((systemWindow) =>
-    hasExpectedTitle(systemWindow, expectedWindowTitlePrefix),
+  return systemWindows.find((systemWindow) =>
+    hasExpectedTitle(systemWindow, expectedTitlePrefix),
   );
-  return matchingSystemWindows[0];
 }
 
-function hasExpectedTitle(systemWindow, expectedWindowTitlePrefix) {
-  return systemWindow.title().startsWith(expectedWindowTitlePrefix);
+function hasExpectedTitle(systemWindow, expectedTitlePrefix) {
+  return systemWindow.title().startsWith(expectedTitlePrefix);
 }
 
 /**

--- a/src/focus-tab.js
+++ b/src/focus-tab.js
@@ -3,21 +3,36 @@
 function run(args) {
   ObjC.import("stdlib");
 
-  const browserName = $.getenv("browser");
   const { windowIndex, tabIndex } = getWindowAndTabIndex(args);
-
-  const browser = Application(browserName);
-  // Defining these at the same time here, before their ordering gets affected by `activateTab`
-  const browserWindow = browser.windows[windowIndex];
-  const systemWindow = getSystemWindow(browserName, windowIndex);
+  const { browser, browserWindow, systemWindow } =
+    getBrowserAndWindows(windowIndex);
 
   activateTab(browser, browserWindow, systemWindow, tabIndex);
 }
 
+/**
+ * Parses the window index and tab index (both 0-indexed) from the query string.
+ */
 function getWindowAndTabIndex(args) {
   const query = args[0];
   const [windowIndex, tabIndex] = query.split(",").map((x) => parseInt(x));
+  console.log(`windowIndex: ${windowIndex}, tabIndex: ${tabIndex}`);
   return { windowIndex, tabIndex };
+}
+
+/**
+ * Returns the browser application object, along with the specific browser window and the system
+ * window object for the given window index.
+ *
+ * We define `browserWindow` and `systemWindow` here at the same time, before the window ordering
+ * gets affected by `activateTab` and `windowIndex` is no longer accurate.
+ */
+function getBrowserAndWindows(windowIndex) {
+  const browserName = $.getenv("browser");
+  const browser = Application(browserName);
+  const browserWindow = browser.windows[windowIndex];
+  const systemWindow = getSystemWindow(browserName, windowIndex);
+  return { browser, browserWindow, systemWindow };
 }
 
 function getSystemWindow(browserName, windowIndex) {
@@ -25,6 +40,10 @@ function getSystemWindow(browserName, windowIndex) {
   return browserProcess.windows[windowIndex];
 }
 
+/**
+ * Activates the tab at the given index in the browser window, focuses the window, and activates the
+ * browser application.
+ */
 function activateTab(browser, browserWindow, systemWindow, tabIndex) {
   browserWindow.activeTabIndex = tabIndex + 1;
   systemWindow.actions["AXRaise"].perform();

--- a/src/focus-tab.js
+++ b/src/focus-tab.js
@@ -2,15 +2,31 @@
 
 function run(args) {
   ObjC.import("stdlib");
-  let browser = $.getenv("browser");
-  let chrome = Application(browser);
-  let query = args[0];
-  let [arg1, arg2] = query.split(",");
-  let windowIndex = parseInt(arg1);
-  let tabIndex = parseInt(arg2);
 
-  chrome.windows[windowIndex].visible = true;
-  chrome.windows[windowIndex].activeTabIndex = tabIndex + 1;
-  chrome.windows[windowIndex].index = 1;
-  chrome.activate();
+  const browserName = $.getenv("browser");
+  const { windowIndex, tabIndex } = getWindowAndTabIndex(args);
+
+  const browser = Application(browserName);
+  // Defining these at the same time here, before their ordering gets affected by `activateTab`
+  const browserWindow = browser.windows[windowIndex];
+  const systemWindow = getSystemWindow(browserName, windowIndex);
+
+  activateTab(browser, browserWindow, systemWindow, tabIndex);
+}
+
+function getWindowAndTabIndex(args) {
+  const query = args[0];
+  const [windowIndex, tabIndex] = query.split(",").map((x) => parseInt(x));
+  return { windowIndex, tabIndex };
+}
+
+function getSystemWindow(browserName, windowIndex) {
+  const browserProcess = Application("System Events").processes[browserName];
+  return browserProcess.windows[windowIndex];
+}
+
+function activateTab(browser, browserWindow, systemWindow, tabIndex) {
+  browserWindow.activeTabIndex = tabIndex + 1;
+  systemWindow.actions["AXRaise"].perform();
+  browser.activate();
 }


### PR DESCRIPTION
Looks like there are a few (duplicate) open issues that this would resolve (#20 , #24 , #43 ).

Not sure you're still active here @epilande  but this PR should work as a fix if you wanted to merge it in.

Credit to @jaekyeom for already knowing to use AXRaise and providing his code in #20 which I expanded on here