### PR TITLE
ci: add GitHub Actions build and release workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: Package workflow
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
 
     steps:
       - name: Checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,30 @@
+name: Build
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    name: Package workflow
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build .alfredworkflow
+        run: |
+          cd src
+          zip -r ../Browser-Tabs.alfredworkflow . -x "*.DS_Store"
+          cd ..
+          echo "✅ Built Browser-Tabs.alfredworkflow ($(du -sh Browser-Tabs.alfredworkflow | cut -f1))"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Browser-Tabs.alfredworkflow
+          path: Browser-Tabs.alfredworkflow
+          retention-days: 7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Stamp version in info.plist
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          python3 - <<EOF
+          import plistlib
+          with open("src/info.plist", "rb") as f:
+              p = plistlib.load(f)
+          p["version"] = "$VERSION"
+          with open("src/info.plist", "wb") as f:
+              plistlib.dump(p, f)
+          print(f"Stamped version: $VERSION")
+          EOF
+
       - name: Build .alfredworkflow
         run: |
           cd src

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   release:
     name: Build & release
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
 
     steps:
       - name: Checkout
@@ -20,15 +20,8 @@ jobs:
       - name: Stamp version in info.plist
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
-          python3 - <<EOF
-          import plistlib
-          with open("src/info.plist", "rb") as f:
-              p = plistlib.load(f)
-          p["version"] = "$VERSION"
-          with open("src/info.plist", "wb") as f:
-              plistlib.dump(p, f)
-          print(f"Stamped version: $VERSION")
-          EOF
+          plutil -replace version -string "$VERSION" src/info.plist
+          echo "Stamped version: $VERSION"
 
       - name: Build .alfredworkflow
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Build & release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build .alfredworkflow
+        run: |
+          cd src
+          zip -r ../Browser-Tabs.alfredworkflow . -x "*.DS_Store"
+          cd ..
+          echo "✅ Built Browser-Tabs.alfredworkflow ($(du -sh Browser-Tabs.alfredworkflow | cut -f1))"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: ${{ github.ref_name }}
+          generate_release_notes: true
+          files: Browser-Tabs.alfredworkflow


### PR DESCRIPTION
## Summary

Adds two GitHub Actions workflows to automate packaging and releasing the Alfred workflow file.

### `build.yml` (runs on push/PR to `main`)
- Zips the contents of `src/` into `Browser-Tabs.alfredworkflow`
- Uploads it as a build artifact (7-day retention) — great for testing changes before a release

### `release.yml` (triggers on `v*.*.*` tag push)
- Builds the same `.alfredworkflow` package
- Creates a GitHub Release automatically with generated release notes
- Attaches `Browser-Tabs.alfredworkflow` as the release asset

## How to release

```bash
git tag v1.0.8
git push origin v1.0.8
```

That's it — Actions takes care of packaging and publishing the release.

## Notes
- The `.alfredworkflow` format is just a zip of the `src/` directory contents
- `.DS_Store` files are excluded from the zip
- Uses `softprops/action-gh-release` for release creation (well-maintained, widely used)