### PR TITLE
fix(arc): replace spaces traversal with batch tab.properties() fetch

### DIFF
--- a/src/focus-tab-arc.js
+++ b/src/focus-tab-arc.js
@@ -1,17 +1,31 @@
 #!/usr/bin/env osascript -l JavaScript
 
 function run(args) {
-  ObjC.import("stdlib");
-  let browser = $.getenv("browser");
-  let chrome = Application(browser);
   let query = args[0];
-  let [arg1, arg2, arg3] = query.split(",");
 
-  let windowIndex = parseInt(arg1);
-  let spaceIndex = parseInt(arg2);
-  let tabIndex = parseInt(arg3);
+  // Arg format: "<tabId>,<url>" — tabId is everything before the first comma
+  let commaIdx = query.indexOf(",");
+  let tabId = commaIdx !== -1 ? query.substring(0, commaIdx) : query;
 
-  chrome.windows[windowIndex].spaces[spaceIndex].focus();
-  chrome.windows[windowIndex].spaces[spaceIndex].tabs[tabIndex].select();
-  chrome.activate();
+  let chrome = Application("Arc");
+  let windowCount = chrome.windows.length;
+
+  for (let w = 0; w < windowCount; w++) {
+    try {
+      // Batch-fetch IDs for all tabs in this window, then select by ID.
+      // Avoids space-index-based selection which breaks when spaces API
+      // changes across Arc versions.
+      let tabProps = chrome.windows[w].tabs.properties();
+
+      for (let t = 0; t < tabProps.length; t++) {
+        if (String(tabProps[t].id) === String(tabId)) {
+          chrome.windows[w].tabs[t].select();
+          chrome.activate();
+          return;
+        }
+      }
+    } catch (_) {
+      // Skip windows that don't support tab enumeration
+    }
+  }
 }

--- a/src/list-tabs-arc.js
+++ b/src/list-tabs-arc.js
@@ -12,41 +12,47 @@ function run(args) {
       ],
     });
   }
+
   let chrome = Application(browser);
   chrome.includeStandardAdditions = true;
+
+  let items = [];
+  let seen = {};
   let windowCount = chrome.windows.length;
-  let allTabs = {};
-  for (let widx = 0; widx < windowCount; widx++) {
-    let spaceCount = chrome.windows[widx].spaces.length;
-    for (let sidx = 0; sidx < spaceCount; sidx++) {
-      for (let i = 0; i < chrome.windows[widx].spaces[sidx].tabs.length; i++) {
-        let k = `${widx}-${sidx}-${i}`;
-        let title = chrome.windows[widx].spaces[sidx].tabs[i].title();
-        let url = chrome.windows[widx].spaces[sidx].tabs[i].url();
-        allTabs[k] = { title, url };
+
+  for (let w = 0; w < windowCount; w++) {
+    try {
+      // Batch-fetch all tab properties in one IPC call per window.
+      // Avoids the per-tab individual AppleScript round-trips that caused
+      // the "stuck forever" hang (issue #58). Follows the same pattern used
+      // by the official Raycast Arc extension.
+      let tabProps = chrome.windows[w].tabs.properties();
+
+      for (let t = 0; t < tabProps.length; t++) {
+        let url = tabProps[t].url || "";
+        let tabId = tabProps[t].id;
+
+        // Skip duplicates and tabs without a URL (e.g. new tab pages)
+        if (!url || seen[url]) continue;
+        seen[url] = true;
+
+        let matchUrl = url.replace(/(^\w+:|^)\/\//, "");
+        let title = tabProps[t].title || matchUrl;
+
+        items.push({
+          title,
+          subtitle: url,
+          quicklookurl: url,
+          // Pass tabId + url so Alfred can also copy the URL via modifier
+          arg: `${tabId},${url}`,
+          match: `${title} ${decodeURIComponent(matchUrl).replace(/[^\w]/g, " ")}`,
+        });
       }
+    } catch (_) {
+      // Skip windows that don't support tab enumeration
+      // (e.g. Little Arc popup windows, mini players)
     }
   }
-  let items = Object.keys(allTabs).reduce((acc, k) => {
-    let [w, s, t] = k.split("-");
-    let url = allTabs[k].url || "";
-    let matchUrl = url.replace(/(^\w+:|^)\/\//, "");
-    let title = allTabs[k].title || matchUrl;
-
-    let o = {
-      title,
-      url,
-      subtitle: url,
-      windowIndex: w,
-      tabIndex: t,
-      spaceIndex: s,
-      quicklookurl: url,
-      arg: `${w},${s},${t},${url}`,
-      match: `${title} ${decodeURIComponent(matchUrl).replace(/[^\w]/g, " ")}`,
-    };
-    acc.push(o);
-    return acc;
-  }, []);
 
   return JSON.stringify({ items });
 }


### PR DESCRIPTION
Fixes #58 — Arc Tabs getting stuck forever.

## Root cause

Two compounding issues in `list-tabs-arc.js`:

**1. Individual AppleScript IPC calls per tab**

The old code called `.title()` and `.url()` separately for every tab in a nested loop — N×2 round-trips to Arc. `tabs.length` was also re-evaluated as an IPC call on every loop iteration. With many tabs or a momentarily unresponsive Arc, this hung indefinitely.

Compare to `list-tabs.js` (Chrome/Brave) which fetches all titles and URLs in 2 total calls.

**2. Spaces API unreliable in Arc 1.70+**

Little Arc popup windows and other special window types don't expose a `spaces` property. Traversing `windows → spaces → tabs` on these windows causes a deadlock. The official Raycast Arc extension (actively maintained by The Browser Company) avoids spaces entirely for tab listing.

## Fix

**`list-tabs-arc.js`** — replaces the `windows → spaces → tabs` nested loop with a per-window batch fetch:
```js
// Before: N×2 IPC calls + spaces traversal
chrome.windows[widx].spaces[sidx].tabs[i].title() // per tab
chrome.windows[widx].spaces[sidx].tabs[i].url()   // per tab

// After: 1 IPC call per window, all properties at once
let tabProps = chrome.windows[w].tabs.properties()
```
A `try/catch` around each window skips unsupported window types (Little Arc, mini players) gracefully.

**`focus-tab-arc.js`** — replaces space/tab index–based selection with stable tab ID lookup:
```js
// Before: brittle space + tab index navigation
chrome.windows[windowIndex].spaces[spaceIndex].focus()
chrome.windows[windowIndex].spaces[spaceIndex].tabs[tabIndex].select()

// After: find tab by ID across all windows
let tabProps = chrome.windows[w].tabs.properties()
if (String(tabProps[t].id) === String(tabId)) { tab.select() }
```

## Validation

This pattern is used by the official [Raycast Arc extension](https://github.com/raycast/extensions/blob/main/extensions/arc/src/arc.ts) (`properties of every tab` / tab ID selection) — battle-tested over 3+ years.

## Arg format change

Arc list items now pass `<tabId>,<url>` instead of `<windowIdx>,<spaceIdx>,<tabIdx>,<url>`. Both `focus-tab-arc.js` scripts are updated in sync.